### PR TITLE
plugins/environments.js: Fix creation of new environments

### DIFF
--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -1,275 +1,278 @@
 const Diffable = require('./diffable')
 
 module.exports = class Environments extends Diffable {
-    constructor(...args) {
-        super(...args)
+  constructor (...args) {
+    super(...args)
 
-        if (this.entries) {
-            // Force all names to lowercase to avoid comparison issues.
-            this.entries.forEach(environment => {
-              environment.name = environment.name.toLowerCase();
-              if(environment.variables) {
-                environment.variables.forEach(variable => {
-                    variable.name = variable.name.toLowerCase();
-                });
-              }
-            })
-          }
+    if (this.entries) {
+      // Force all names to lowercase to avoid comparison issues.
+      this.entries.forEach(environment => {
+        environment.name = environment.name.toLowerCase()
+        if (environment.variables) {
+          environment.variables.forEach(variable => {
+            variable.name = variable.name.toLowerCase()
+          })
+        }
+      })
     }
+  }
 
-    async find() {
-        const { data: { environments } } = await this.github.request('GET /repos/:org/:repo/environments', {
-            org: this.repo.owner,
-            repo: this.repo.repo
-        });
+  async find () {
+    const { data: { environments } } = await this.github.request('GET /repos/:org/:repo/environments', {
+      org: this.repo.owner,
+      repo: this.repo.repo
+    })
 
-        let environments_mapped = [];
+    const environmentsMapped = []
 
-        for(let environment of environments) {
-            const mapped = {
-                name: environment.name.toLowerCase(),
+    for (const environment of environments) {
+      const mapped = {
+        name: environment.name.toLowerCase(),
+        repo: this.repo.repo,
+        wait_timer: (environment.protection_rules.find(rule => rule.type === 'wait_timer') || { wait_timer: 0 }).wait_timer,
+        prevent_self_review: (environment.protection_rules.find(rule => rule.type === 'required_reviewers') || { prevent_self_review: false }).prevent_self_review,
+        reviewers: (environment.protection_rules.find(rule => rule.type === 'required_reviewers') || { reviewers: [] }).reviewers.map(reviewer => ({ id: reviewer.reviewer.id, type: reviewer.type })),
+        deployment_branch_policy: environment.deployment_branch_policy === null
+          ? null
+          : {
+              protected_branches: (environment.deployment_branch_policy || { protected_branches: false }).protected_branches,
+              custom_branch_policies: (environment.deployment_branch_policy || { custom_branch_policies: false }).custom_branch_policies && (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
+                org: this.repo.owner,
                 repo: this.repo.repo,
-                wait_timer: (environment.protection_rules.find(rule => rule.type === 'wait_timer') || { wait_timer: 0 }).wait_timer,
-                prevent_self_review: (environment.protection_rules.find(rule => rule.type === 'required_reviewers') || { prevent_self_review: false }).prevent_self_review,
-                reviewers: (environment.protection_rules.find(rule => rule.type === 'required_reviewers') || { reviewers: [] }).reviewers.map(reviewer => ({id: reviewer.reviewer.id, type: reviewer.type})),
-                deployment_branch_policy: environment.deployment_branch_policy === null ? null : {
-                    protected_branches: (environment.deployment_branch_policy || { protected_branches: false }).protected_branches,
-                    custom_branch_policies: (environment.deployment_branch_policy || { custom_branch_policies: false }).custom_branch_policies && (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
-                        org: this.repo.owner,
-                        repo: this.repo.repo,
-                        environment_name: environment.name
-                    })).data.branch_policies.map(policy => ({
-                        name: policy.name
-                    }))
-                },
-                variables: (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/variables', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: environment.name
-                })).data.variables.map(variable => ({name: variable.name.toLowerCase(), value: variable.value})),
-                deployment_protection_rules: (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: environment.name
-                })).data.custom_deployment_protection_rules.map(rule => ({
-                    app_id: rule.app.id,
-                    id: rule.id
-                }))
-            }
-            environments_mapped.push(mapped);
-            //console.log(mapped);
-        }
-
-        return environments_mapped;
+                environment_name: environment.name
+              })).data.branch_policies.map(policy => ({
+                name: policy.name
+              }))
+            },
+        variables: (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/variables', {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: environment.name
+        })).data.variables.map(variable => ({ name: variable.name.toLowerCase(), value: variable.value })),
+        deployment_protection_rules: (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: environment.name
+        })).data.custom_deployment_protection_rules.map(rule => ({
+          app_id: rule.app.id,
+          id: rule.id
+        }))
+      }
+      environmentsMapped.push(mapped)
+      // console.log(mapped);
     }
 
-    comparator(existing, attrs) {
-        return existing.name === attrs.name
+    return environmentsMapped
+  }
+
+  comparator (existing, attrs) {
+    return existing.name === attrs.name
+  }
+
+  getChanged (existing, attrs) {
+    if (!attrs.wait_timer) attrs.wait_timer = 0
+    if (!attrs.prevent_self_review) attrs.prevent_self_review = false
+    if (!attrs.reviewers) attrs.reviewers = []
+    if (!attrs.deployment_branch_policy) attrs.deployment_branch_policy = null
+    if (!attrs.variables) attrs.variables = []
+    if (!attrs.deployment_protection_rules) attrs.deployment_protection_rules = []
+
+    const waitTimer = existing.wait_timer !== attrs.wait_timer
+    const preventSelfReview = existing.prevent_self_review !== attrs.prevent_self_review
+    const reviewers = JSON.stringify(existing.reviewers.sort((x1, x2) => x1.id - x2.id)) !== JSON.stringify(attrs.reviewers.sort((x1, x2) => x1.id - x2.id))
+
+    let existingCustomBranchPolicies = existing.deployment_branch_policy === null ? null : existing.deployment_branch_policy.custom_branch_policies
+    if (typeof (existingCustomBranchPolicies) === 'object' && existingCustomBranchPolicies !== null) {
+      existingCustomBranchPolicies = existingCustomBranchPolicies.sort()
     }
-
-    getChanged(existing, attrs) {
-        if (!attrs.wait_timer) attrs.wait_timer = 0;
-        if (!attrs.prevent_self_review) attrs.prevent_self_review = false;
-        if (!attrs.reviewers) attrs.reviewers = [];
-        if (!attrs.deployment_branch_policy) attrs.deployment_branch_policy = null;
-        if(!attrs.variables) attrs.variables = [];
-        if(!attrs.deployment_protection_rules) attrs.deployment_protection_rules = [];
-
-        const wait_timer = existing.wait_timer !== attrs.wait_timer;
-        const prevent_self_review = existing.prevent_self_review !== attrs.prevent_self_review;
-        const reviewers = JSON.stringify(existing.reviewers.sort((x1, x2) => x1.id - x2.id)) !== JSON.stringify(attrs.reviewers.sort((x1, x2) => x1.id - x2.id));
-        
-        let existing_custom_branch_policies = existing.deployment_branch_policy === null ? null : existing.deployment_branch_policy.custom_branch_policies;
-        if(typeof(existing_custom_branch_policies) === 'object' && existing_custom_branch_policies !== null) {
-            existing_custom_branch_policies = existing_custom_branch_policies.sort();
-        }
-        let attrs_custom_branch_policies = attrs.deployment_branch_policy === null ? null : attrs.deployment_branch_policy.custom_branch_policies;
-        if(typeof(attrs_custom_branch_policies) === 'object' && attrs_custom_branch_policies !== null) {
-            attrs_custom_branch_policies = attrs_custom_branch_policies.sort();
-        }
-        let deployment_branch_policy;
-        if(existing.deployment_branch_policy === attrs.deployment_branch_policy) {
-            deployment_branch_policy = false;
-        }
-        else {
-            deployment_branch_policy = (
-                (existing.deployment_branch_policy === null && attrs.deployment_branch_policy !== null) ||
+    let attrsCustomBranchPolicies = attrs.deployment_branch_policy === null ? null : attrs.deployment_branch_policy.custom_branch_policies
+    if (typeof (attrsCustomBranchPolicies) === 'object' && attrsCustomBranchPolicies !== null) {
+      attrsCustomBranchPolicies = attrsCustomBranchPolicies.sort()
+    }
+    let deploymentBranchPolicy
+    if (existing.deployment_branch_policy === attrs.deployment_branch_policy) {
+      deploymentBranchPolicy = false
+    } else {
+      deploymentBranchPolicy = (
+        (existing.deployment_branch_policy === null && attrs.deployment_branch_policy !== null) ||
                 (existing.deployment_branch_policy !== null && attrs.deployment_branch_policy === null) ||
                 (existing.deployment_branch_policy.protected_branches !== attrs.deployment_branch_policy.protected_branches) ||
-                 (JSON.stringify(existing_custom_branch_policies) !== JSON.stringify(attrs_custom_branch_policies))
-            );
-        }
-
-        const variables = JSON.stringify(existing.variables.sort((x1, x2) => x1.name - x2.name)) !== JSON.stringify(attrs.variables.sort((x1, x2) => x1.name - x2.name));
-        const deployment_protection_rules = JSON.stringify(existing.deployment_protection_rules.map(x => ({app_id: x.app_id})).sort((x1, x2) => x1.app_id - x2.app_id)) !== JSON.stringify(attrs.deployment_protection_rules.map(x => ({app_id: x.app_id})).sort((x1, x2) => x1.app_id - x2.app_id));
-
-        return {wait_timer, prevent_self_review, reviewers, deployment_branch_policy, variables, deployment_protection_rules};
+                 (JSON.stringify(existingCustomBranchPolicies) !== JSON.stringify(attrsCustomBranchPolicies))
+      )
     }
 
-    changed(existing, attrs) {
-        const {wait_timer, prevent_self_review, reviewers, deployment_branch_policy, variables, deployment_protection_rules} = this.getChanged(existing, attrs);
+    const variables = JSON.stringify(existing.variables.sort((x1, x2) => x1.name - x2.name)) !== JSON.stringify(attrs.variables.sort((x1, x2) => x1.name - x2.name))
+    const deploymentProtectionRules = JSON.stringify(existing.deployment_protection_rules.map(x => ({ app_id: x.app_id })).sort((x1, x2) => x1.app_id - x2.app_id)) !== JSON.stringify(attrs.deployment_protection_rules.map(x => ({ app_id: x.app_id })).sort((x1, x2) => x1.app_id - x2.app_id))
 
-        return wait_timer || prevent_self_review || reviewers || deployment_branch_policy || variables || deployment_protection_rules;
+    return { wait_timer: waitTimer, prevent_self_review: preventSelfReview, reviewers, deployment_branch_policy: deploymentBranchPolicy, variables, deployment_protection_rules: deploymentProtectionRules }
+  }
+
+  changed (existing, attrs) {
+    const { wait_timer: waitTimer, prevent_self_review: preventSelfReview, reviewers, deployment_branch_policy: deploymentBranchPolicy, variables, deployment_protection_rules: deploymentProtectionRules } = this.getChanged(existing, attrs)
+
+    return waitTimer || preventSelfReview || reviewers || deploymentBranchPolicy || variables || deploymentProtectionRules
+  }
+
+  async update (existing, attrs) {
+    const { wait_timer: waitTimer, prevent_self_review: preventSelfReview, reviewers, deployment_branch_policy: deploymentBranchPolicy, variables, deployment_protection_rules: deploymentProtectionRules } = this.getChanged(existing, attrs)
+
+    if (waitTimer || preventSelfReview || reviewers || deploymentBranchPolicy) {
+      await this.github.request('PUT /repos/:org/:repo/environments/:environment_name', {
+        org: this.repo.owner,
+        repo: this.repo.repo,
+        environment_name: attrs.name,
+        wait_timer: attrs.wait_timer,
+        prevent_self_review: attrs.prevent_self_review,
+        reviewers: attrs.reviewers,
+        deployment_branch_policy: attrs.deployment_branch_policy === null
+          ? null
+          : {
+              protected_branches: attrs.deployment_branch_policy.protected_branches,
+              custom_branch_policies: !!attrs.deployment_branch_policy.custom_branch_policies
+            }
+      })
     }
 
-    async update(existing, attrs) {
-        const {wait_timer, prevent_self_review, reviewers, deployment_branch_policy, variables, deployment_protection_rules} = this.getChanged(existing, attrs);
+    if (deploymentBranchPolicy && attrs.deployment_branch_policy && attrs.deployment_branch_policy.custom_branch_policies) {
+      const existingPolicies = (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
+        org: this.repo.owner,
+        repo: this.repo.repo,
+        environment_name: attrs.name
+      })).data.branch_policies
 
-        if(wait_timer || prevent_self_review || reviewers || deployment_branch_policy) {
-            await this.github.request(`PUT /repos/:org/:repo/environments/:environment_name`, {
-                org: this.repo.owner,
-                repo: this.repo.repo,
-                environment_name: attrs.name,
-                wait_timer: attrs.wait_timer,
-                prevent_self_review: attrs.prevent_self_review,
-                reviewers: attrs.reviewers,
-                deployment_branch_policy: attrs.deployment_branch_policy === null ? null : {
-                    protected_branches: attrs.deployment_branch_policy.protected_branches,
-                    custom_branch_policies: !!attrs.deployment_branch_policy.custom_branch_policies
-                }
+      for (const policy of existingPolicies) {
+        await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:branch_policy_id', {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: attrs.name,
+          branch_policy_id: policy.id
+        })
+      }
+
+      for (const policy of attrs.deployment_branch_policy.custom_branch_policies) {
+        await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: attrs.name,
+          name: policy
+        })
+      }
+    }
+
+    if (variables) {
+      let existingVariables = [...existing.variables]
+      for (const variable of attrs.variables) {
+        const existingVariable = existingVariables.find((_var) => _var.name === variable.name)
+        if (existingVariable) {
+          existingVariables = existingVariables.filter(_var => _var.name !== variable.name)
+          if (existingVariable.value !== variable.value) {
+            await this.github.request('PATCH /repos/:org/:repo/environments/:environment_name/variables/:variable_name', {
+              org: this.repo.owner,
+              repo: this.repo.repo,
+              environment_name: attrs.name,
+              variable_name: variable.name,
+              value: variable.value
             })
-        }
-
-        if(deployment_branch_policy && attrs.deployment_branch_policy && attrs.deployment_branch_policy.custom_branch_policies) {
-            const existingPolicies = (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
-                org: this.repo.owner,
-                repo: this.repo.repo,
-                environment_name: attrs.name
-            })).data.branch_policies;
-
-            for(let policy of existingPolicies) {
-                await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:branch_policy_id', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    branch_policy_id: policy.id
-                });
-            }
-
-            for(let policy of attrs.deployment_branch_policy.custom_branch_policies) {
-                await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    name: policy
-                });
-            }
-        }
-
-        if(variables) {
-            let existingVariables = [...existing.variables];
-            for(let variable of attrs.variables) {
-                const existingVariable = existingVariables.find((_var) => _var.name === variable.name);
-                if(existingVariable) {
-                    existingVariables = existingVariables.filter(_var => _var.name !== variable.name);
-                    if(existingVariable.value !== variable.value) {
-                        await this.github.request(`PATCH /repos/:org/:repo/environments/:environment_name/variables/:variable_name`, {
-                            org: this.repo.owner,
-                            repo: this.repo.repo,
-                            environment_name: attrs.name,
-                            variable_name: variable.name,
-                            value: variable.value
-                        });
-                    }
-                }
-                else {
-                    await this.github.request(`POST /repos/:org/:repo/environments/:environment_name/variables`, {
-                        org: this.repo.owner,
-                        repo: this.repo.repo,
-                        environment_name: attrs.name,
-                        name: variable.name,
-                        value: variable.value
-                    });
-                }
-            }
-
-            for(let variable of existingVariables) {
-                await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name/variables/:variable_name', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    variable_name: variable.name
-                });
-            }
-        }
-
-        if(deployment_protection_rules) {
-            let existingRules = [...existing.deployment_protection_rules];
-            for(let rule of attrs.deployment_protection_rules) {
-                const existingRule = existingRules.find((_rule) => _rule.id === rule.id);
-
-                if(!existingRule) {
-                    await this.github.request(`POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules`, {
-                        org: this.repo.owner,
-                        repo: this.repo.repo,
-                        environment_name: attrs.name,
-                        integration_id: rule.app_id
-                    });
-                }
-            }
-
-            for(let rule of existingRules) {
-                await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name/deployment_protection_rules/:rule_id', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    rule_id: rule.id
-                });
-            }
-        }
-    }
-
-    async add(attrs) {
-        await this.github.request(`PUT /repos/:org/:repo/environments/:environment_name`, {
+          }
+        } else {
+          await this.github.request('POST /repos/:org/:repo/environments/:environment_name/variables', {
             org: this.repo.owner,
             repo: this.repo.repo,
             environment_name: attrs.name,
-            wait_timer: attrs.wait_timer,
-            prevent_self_review: attrs.prevent_self_review,
-            reviewers: attrs.reviewers,
-            deployment_branch_policy: attrs.deployment_branch_policy === null ? null : {
-                protected_branches: attrs.deployment_branch_policy.protected_branches,
-                custom_branch_policies: !!attrs.deployment_branch_policy.custom_branch_policies
-            }
-        });
-
-        if(attrs.deployment_branch_policy && attrs.deployment_branch_policy.custom_branch_policies) {
-            for(let policy of attrs.deployment_branch_policy.custom_branch_policies) {
-                await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    name: policy.name
-                });
-            }
+            name: variable.name,
+            value: variable.value
+          })
         }
-        
+      }
 
-        for(let variable of attrs.variables) {
-            await this.github.request(`POST /repos/:org/:repo/environments/:environment_name/variables`, {
-                org: this.repo.owner,
-                repo: this.repo.repo,
-                environment_name: attrs.name,
-                name: variable.name,
-                value: variable.value
-            });
-        }
-
-        for(let rule of attrs.deployment_protection_rules) {
-            await this.github.request(`POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules`, {
-                org: this.repo.owner,
-                repo: this.repo.repo,
-                environment_name: attrs.name,
-                integration_id: rule.app_id
-            });
-        }
+      for (const variable of existingVariables) {
+        await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name/variables/:variable_name', {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: attrs.name,
+          variable_name: variable.name
+        })
+      }
     }
 
-    async remove(existing) {
-        await this.github.request(`DELETE /repos/:org/:repo/environments/:environment_name`, {
+    if (deploymentProtectionRules) {
+      const existingRules = [...existing.deployment_protection_rules]
+      for (const rule of attrs.deployment_protection_rules) {
+        const existingRule = existingRules.find((_rule) => _rule.id === rule.id)
+
+        if (!existingRule) {
+          await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', {
             org: this.repo.owner,
             repo: this.repo.repo,
-            environment_name: existing.name
-        });
+            environment_name: attrs.name,
+            integration_id: rule.app_id
+          })
+        }
+      }
+
+      for (const rule of existingRules) {
+        await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name/deployment_protection_rules/:rule_id', {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: attrs.name,
+          rule_id: rule.id
+        })
+      }
     }
+  }
+
+  async add (attrs) {
+    await this.github.request('PUT /repos/:org/:repo/environments/:environment_name', {
+      org: this.repo.owner,
+      repo: this.repo.repo,
+      environment_name: attrs.name,
+      wait_timer: attrs.wait_timer,
+      prevent_self_review: attrs.prevent_self_review,
+      reviewers: attrs.reviewers,
+      deployment_branch_policy: attrs.deployment_branch_policy === null
+        ? null
+        : {
+            protected_branches: attrs.deployment_branch_policy.protected_branches,
+            custom_branch_policies: !!attrs.deployment_branch_policy.custom_branch_policies
+          }
+    })
+
+    if (attrs.deployment_branch_policy && attrs.deployment_branch_policy.custom_branch_policies) {
+      for (const policy of attrs.deployment_branch_policy.custom_branch_policies) {
+        await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: attrs.name,
+          name: policy.name
+        })
+      }
+    }
+
+    for (const variable of attrs.variables) {
+      await this.github.request('POST /repos/:org/:repo/environments/:environment_name/variables', {
+        org: this.repo.owner,
+        repo: this.repo.repo,
+        environment_name: attrs.name,
+        name: variable.name,
+        value: variable.value
+      })
+    }
+
+    for (const rule of attrs.deployment_protection_rules) {
+      await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', {
+        org: this.repo.owner,
+        repo: this.repo.repo,
+        environment_name: attrs.name,
+        integration_id: rule.app_id
+      })
+    }
+  }
+
+  async remove (existing) {
+    await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name', {
+      org: this.repo.owner,
+      repo: this.repo.repo,
+      environment_name: existing.name
+    })
+  }
 }

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -229,7 +229,7 @@ module.exports = class Environments extends Diffable {
       wait_timer: attrs.wait_timer,
       prevent_self_review: attrs.prevent_self_review,
       reviewers: attrs.reviewers,
-      deployment_branch_policy: attrs.deployment_branch_policy === null
+      deployment_branch_policy: attrs.deployment_branch_policy == null
         ? null
         : {
             protected_branches: attrs.deployment_branch_policy.protected_branches,
@@ -248,23 +248,27 @@ module.exports = class Environments extends Diffable {
       }
     }
 
-    for (const variable of attrs.variables) {
-      await this.github.request('POST /repos/:org/:repo/environments/:environment_name/variables', {
-        org: this.repo.owner,
-        repo: this.repo.repo,
-        environment_name: attrs.name,
-        name: variable.name,
-        value: variable.value
-      })
+    if (attrs.variables) {
+      for (const variable of attrs.variables) {
+        await this.github.request('POST /repos/:org/:repo/environments/:environment_name/variables', {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: attrs.name,
+          name: variable.name,
+          value: variable.value
+        })
+      }
     }
 
-    for (const rule of attrs.deployment_protection_rules) {
-      await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', {
-        org: this.repo.owner,
-        repo: this.repo.repo,
-        environment_name: attrs.name,
-        integration_id: rule.app_id
-      })
+    if (attrs.deployment_protection_rules) {
+      for (const rule of attrs.deployment_protection_rules) {
+        await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: attrs.name,
+          integration_id: rule.app_id
+        })
+      }
     }
   }
 

--- a/test/unit/lib/plugins/environments.test.js
+++ b/test/unit/lib/plugins/environments.test.js
@@ -5,7 +5,7 @@ describe('Environments', () => {
     let github
     const org = 'bkeepers'
     const repo = 'test'
-  
+
     function fillEnvironment(attrs) {
         if (!attrs.wait_timer) attrs.wait_timer = 0;
         if (!attrs.prevent_self_review) attrs.prevent_self_review = false;
@@ -80,7 +80,62 @@ describe('Environments', () => {
                         app_id: 1
                     }
                 ]
-            }
+            },
+            {
+                name: 'new-wait-timer',
+                wait_timer: 1
+            },
+            {
+                name: 'new-reviewers',
+                reviewers: [
+                    {
+                        type: 'User',
+                        id: 1
+                    },
+                    {
+                        type: 'Team',
+                        id: 2
+                    }
+                ]
+            },
+            {
+                name: 'new-prevent-self-review',
+                prevent_self_review: true
+            },
+            {
+                name: 'new-deployment-branch-policy',
+                deployment_branch_policy: {
+                    protected_branches: true,
+                    custom_branch_policies: false
+                }
+            },
+            {
+                name: 'new-deployment-branch-policy-custom',
+                deployment_branch_policy: {
+                    protected_branches: false,
+                    custom_branch_policies: [
+                        'master',
+                        'dev'
+                    ]
+                }
+            },
+            {
+                name: 'new-variables',
+                variables: [
+                    {
+                        name: 'test',
+                        value: 'test'
+                    }
+                ]
+            },
+            {
+                name: 'new-deployment-protection-rules',
+                deployment_protection_rules: [
+                    {
+                        app_id: 1
+                    }
+                ]
+            },
         ], {
             debug: function() {}
         });
@@ -121,7 +176,7 @@ describe('Environments', () => {
                     ]
                 }
             });
-        
+
         ['wait-timer', 'reviewers', 'prevent-self-review', 'deployment-branch-policy', 'deployment-branch-policy-custom', 'variables', 'deployment-protection-rules'].forEach((environment_name) => {
             when(github.request)
                 .calledWith('GET /repos/:org/:repo/environments/:environment_name/variables', { org, repo, environment_name })
@@ -139,7 +194,7 @@ describe('Environments', () => {
                     data: {
                         custom_deployment_protection_rules: []
                     }
-                }) 
+                })
         });
 
         when(github.request)


### PR DESCRIPTION
Currently if environments do not exist in the target repository, they cannot be created
if all properties are not populated.

This PR performs a lint of the environments plugin file (first commit) before adding new
test cases to cover the creation of environments that do not exist.

The command `eslint --fix ./lib/plugins/environments.js`
was used to lint the plugin and some variable names were
updated to camel case manually.