### PR TITLE
Fix support for uppercase environment variables

### DIFF
--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -26,10 +26,14 @@ on:
           - rc
           - snapshot
         required: false
-     
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   build:
@@ -48,7 +52,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
-        uses: docker/login-action@v3 
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -71,7 +75,7 @@ jobs:
           sleep 10
           curl http://localhost:3000
       - run: echo "${{ github.ref }}"
-      - name: Tag a final release 
+      - name: Tag a final release
         id: prerelease
         uses: actionsdesk/semver@0.6.0-rc.10
         with:

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -10,11 +10,7 @@ module.exports = class Environments extends Diffable {
       // Force all names to lowercase to avoid comparison issues.
       this.entries.forEach((environment) => {
         environment.name = environment.name.toLowerCase()
-        if (environment.variables) {
-          environment.variables.forEach((variable) => {
-            variable.name = variable.name.toLowerCase()
-          })
-        }
+        // Do not force variables to lowercase as they are case-sensitive on create (POST).
       })
     }
   }
@@ -297,11 +293,11 @@ module.exports = class Environments extends Diffable {
 
       for (const variable of attrs.variables) {
         const existingVariable = existingVariables.find(
-          (_var) => _var.name === variable.name
+          (_var) => _var.name === variable.name.toLowerCase()
         )
         if (existingVariable) {
           existingVariables = existingVariables.filter(
-            (_var) => _var.name === variable.name
+            (_var) => _var.name !== variable.name.toLowerCase()
           )
           if (existingVariable.value !== variable.value) {
             await this.github.request(

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -1,297 +1,469 @@
+/* eslint-disable camelcase */
 const Diffable = require('./diffable')
-const MergeDeep = require('../mergeDeep')
 const NopCommand = require('../nopcommand')
 
 module.exports = class Environments extends Diffable {
-    constructor(...args) {
-        super(...args)
+  constructor (...args) {
+    super(...args)
 
-        if (this.entries) {
-            // Force all names to lowercase to avoid comparison issues.
-            this.entries.forEach(environment => {
-              environment.name = environment.name.toLowerCase();
-              if(environment.variables) {
-                environment.variables.forEach(variable => {
-                    variable.name = variable.name.toLowerCase();
-                });
-              }
-            })
+    if (this.entries) {
+      // Force all names to lowercase to avoid comparison issues.
+      this.entries.forEach((environment) => {
+        environment.name = environment.name.toLowerCase()
+        if (environment.variables) {
+          environment.variables.forEach((variable) => {
+            variable.name = variable.name.toLowerCase()
+          })
         }
+      })
     }
+  }
 
-    async find() {
-        const { data: { environments } } = await this.github.request('GET /repos/:org/:repo/environments', {
-            org: this.repo.owner,
-            repo: this.repo.repo
-        });
+  async find () {
+    const {
+      data: { environments }
+    } = await this.github.request('GET /repos/:org/:repo/environments', {
+      org: this.repo.owner,
+      repo: this.repo.repo
+    })
 
-        let environments_mapped = [];
+    const environments_mapped = []
 
-        for(let environment of environments) {
-            const mapped = {
-                name: environment.name.toLowerCase(),
-                repo: this.repo.repo,
-                wait_timer: (environment.protection_rules.find(rule => rule.type === 'wait_timer') || { wait_timer: 0 }).wait_timer,
-                prevent_self_review: (environment.protection_rules.find(rule => rule.type === 'required_reviewers') || { prevent_self_review: false }).prevent_self_review,
-                reviewers: (environment.protection_rules.find(rule => rule.type === 'required_reviewers') || { reviewers: [] }).reviewers.map(reviewer => ({id: reviewer.reviewer.id, type: reviewer.type})),
-                deployment_branch_policy: environment.deployment_branch_policy === null ? null : {
-                    protected_branches: (environment.deployment_branch_policy || { protected_branches: false }).protected_branches,
-                    custom_branch_policies: (environment.deployment_branch_policy || { custom_branch_policies: false }).custom_branch_policies && (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
+    for (const environment of environments) {
+      const mapped = {
+        name: environment.name.toLowerCase(),
+        repo: this.repo.repo,
+        wait_timer: (
+          environment.protection_rules.find(
+            (rule) => rule.type === 'wait_timer'
+          ) || { wait_timer: 0 }
+        ).wait_timer,
+        prevent_self_review: (
+          environment.protection_rules.find(
+            (rule) => rule.type === 'required_reviewers'
+          ) || { prevent_self_review: false }
+        ).prevent_self_review,
+        reviewers: (
+          environment.protection_rules.find(
+            (rule) => rule.type === 'required_reviewers'
+          ) || { reviewers: [] }
+        ).reviewers.map((reviewer) => ({
+          id: reviewer.reviewer.id,
+          type: reviewer.type
+        })),
+        deployment_branch_policy:
+          environment.deployment_branch_policy === null
+            ? null
+            : {
+                protected_branches: (
+                  environment.deployment_branch_policy || {
+                    protected_branches: false
+                  }
+                ).protected_branches,
+                custom_branch_policies:
+                  (
+                    environment.deployment_branch_policy || {
+                      custom_branch_policies: false
+                    }
+                  ).custom_branch_policies &&
+                  (
+                    await this.github.request(
+                      'GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+                      {
                         org: this.repo.owner,
                         repo: this.repo.repo,
                         environment_name: environment.name
-                    })).data.branch_policies.map(policy => ({
-                        name: policy.name
-                    }))
-                },
-                variables: (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/variables', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: environment.name
-                })).data.variables.map(variable => ({name: variable.name.toLowerCase(), value: variable.value})),
-                deployment_protection_rules: (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: environment.name
-                })).data.custom_deployment_protection_rules.map(rule => ({
-                    app_id: rule.app.id,
-                    id: rule.id
-                }))
+                      }
+                    )
+                  ).data.branch_policies.map((policy) => ({
+                    name: policy.name
+                  }))
+              },
+        variables: (
+          await this.github.request(
+            'GET /repos/:org/:repo/environments/:environment_name/variables',
+            {
+              org: this.repo.owner,
+              repo: this.repo.repo,
+              environment_name: environment.name
             }
-            environments_mapped.push(mapped);
-            //console.log(mapped);
-        }
-
-        return environments_mapped;
+          )
+        ).data.variables.map((variable) => ({
+          name: variable.name.toLowerCase(),
+          value: variable.value
+        })),
+        deployment_protection_rules: (
+          await this.github.request(
+            'GET /repos/:org/:repo/environments/:environment_name/deployment_protection_rules',
+            {
+              org: this.repo.owner,
+              repo: this.repo.repo,
+              environment_name: environment.name
+            }
+          )
+        ).data.custom_deployment_protection_rules.map((rule) => ({
+          app_id: rule.app.id,
+          id: rule.id
+        }))
+      }
+      environments_mapped.push(mapped)
+      // console.log(mapped);
     }
 
-    comparator(existing, attrs) {
-        return existing.name === attrs.name
+    return environments_mapped
+  }
+
+  comparator (existing, attrs) {
+    return existing.name === attrs.name
+  }
+
+  getChanged (existing, attrs) {
+    if (!attrs.wait_timer) attrs.wait_timer = 0
+    if (!attrs.prevent_self_review) attrs.prevent_self_review = false
+    if (!attrs.reviewers) attrs.reviewers = []
+    if (!attrs.deployment_branch_policy) attrs.deployment_branch_policy = null
+    if (!attrs.variables) attrs.variables = []
+    if (!attrs.deployment_protection_rules) { attrs.deployment_protection_rules = [] }
+
+    const wait_timer = existing.wait_timer !== attrs.wait_timer
+    const prevent_self_review =
+      existing.prevent_self_review !== attrs.prevent_self_review
+    const reviewers =
+      JSON.stringify(existing.reviewers.sort((x1, x2) => x1.id - x2.id)) !==
+      JSON.stringify(attrs.reviewers.sort((x1, x2) => x1.id - x2.id))
+
+    let existing_custom_branch_policies =
+      existing.deployment_branch_policy === null
+        ? null
+        : existing.deployment_branch_policy.custom_branch_policies
+    if (
+      typeof existing_custom_branch_policies === 'object' &&
+      existing_custom_branch_policies !== null
+    ) {
+      existing_custom_branch_policies = existing_custom_branch_policies.sort()
+    }
+    let attrs_custom_branch_policies =
+      attrs.deployment_branch_policy === null
+        ? null
+        : attrs.deployment_branch_policy.custom_branch_policies
+    if (
+      typeof attrs_custom_branch_policies === 'object' &&
+      attrs_custom_branch_policies !== null
+    ) {
+      attrs_custom_branch_policies = attrs_custom_branch_policies.sort()
+    }
+    let deployment_branch_policy
+    if (existing.deployment_branch_policy === attrs.deployment_branch_policy) {
+      deployment_branch_policy = false
+    } else {
+      deployment_branch_policy =
+        (existing.deployment_branch_policy === null &&
+          attrs.deployment_branch_policy !== null) ||
+        (existing.deployment_branch_policy !== null &&
+          attrs.deployment_branch_policy === null) ||
+        existing.deployment_branch_policy.protected_branches !==
+          attrs.deployment_branch_policy.protected_branches ||
+        JSON.stringify(existing_custom_branch_policies) !==
+          JSON.stringify(attrs_custom_branch_policies)
     }
 
-    getChanged(existing, attrs) {
-        if (!attrs.wait_timer) attrs.wait_timer = 0;
-        if (!attrs.prevent_self_review) attrs.prevent_self_review = false;
-        if (!attrs.reviewers) attrs.reviewers = [];
-        if (!attrs.deployment_branch_policy) attrs.deployment_branch_policy = null;
-        if(!attrs.variables) attrs.variables = [];
-        if(!attrs.deployment_protection_rules) attrs.deployment_protection_rules = [];
+    const variables =
+      JSON.stringify(existing.variables.sort((x1, x2) => x1.name - x2.name)) !==
+      JSON.stringify(attrs.variables.sort((x1, x2) => x1.name - x2.name))
+    const deployment_protection_rules =
+      JSON.stringify(
+        existing.deployment_protection_rules
+          .map((x) => ({ app_id: x.app_id }))
+          .sort((x1, x2) => x1.app_id - x2.app_id)
+      ) !==
+      JSON.stringify(
+        attrs.deployment_protection_rules
+          .map((x) => ({ app_id: x.app_id }))
+          .sort((x1, x2) => x1.app_id - x2.app_id)
+      )
 
-        const wait_timer = existing.wait_timer !== attrs.wait_timer;
-        const prevent_self_review = existing.prevent_self_review !== attrs.prevent_self_review;
-        const reviewers = JSON.stringify(existing.reviewers.sort((x1, x2) => x1.id - x2.id)) !== JSON.stringify(attrs.reviewers.sort((x1, x2) => x1.id - x2.id));
-
-        let existing_custom_branch_policies = existing.deployment_branch_policy === null ? null : existing.deployment_branch_policy.custom_branch_policies;
-        if(typeof(existing_custom_branch_policies) === 'object' && existing_custom_branch_policies !== null) {
-            existing_custom_branch_policies = existing_custom_branch_policies.sort();
-        }
-        let attrs_custom_branch_policies = attrs.deployment_branch_policy === null ? null : attrs.deployment_branch_policy.custom_branch_policies;
-        if(typeof(attrs_custom_branch_policies) === 'object' && attrs_custom_branch_policies !== null) {
-            attrs_custom_branch_policies = attrs_custom_branch_policies.sort();
-        }
-        let deployment_branch_policy;
-        if(existing.deployment_branch_policy === attrs.deployment_branch_policy) {
-            deployment_branch_policy = false;
-        }
-        else {
-            deployment_branch_policy = (
-                (existing.deployment_branch_policy === null && attrs.deployment_branch_policy !== null) ||
-                (existing.deployment_branch_policy !== null && attrs.deployment_branch_policy === null) ||
-                (existing.deployment_branch_policy.protected_branches !== attrs.deployment_branch_policy.protected_branches) ||
-                 (JSON.stringify(existing_custom_branch_policies) !== JSON.stringify(attrs_custom_branch_policies))
-            );
-        }
-
-        const variables = JSON.stringify(existing.variables.sort((x1, x2) => x1.name - x2.name)) !== JSON.stringify(attrs.variables.sort((x1, x2) => x1.name - x2.name));
-        const deployment_protection_rules = JSON.stringify(existing.deployment_protection_rules.map(x => ({app_id: x.app_id})).sort((x1, x2) => x1.app_id - x2.app_id)) !== JSON.stringify(attrs.deployment_protection_rules.map(x => ({app_id: x.app_id})).sort((x1, x2) => x1.app_id - x2.app_id));
-
-        return {wait_timer, prevent_self_review, reviewers, deployment_branch_policy, variables, deployment_protection_rules};
+    return {
+      wait_timer,
+      prevent_self_review,
+      reviewers,
+      deployment_branch_policy,
+      variables,
+      deployment_protection_rules
     }
+  }
 
-    changed(existing, attrs) {
-        const {wait_timer, prevent_self_review, reviewers, deployment_branch_policy, variables, deployment_protection_rules} = this.getChanged(existing, attrs);
+  changed (existing, attrs) {
+    const {
+      wait_timer,
+      prevent_self_review,
+      reviewers,
+      deployment_branch_policy,
+      variables,
+      deployment_protection_rules
+    } = this.getChanged(existing, attrs)
 
-        return wait_timer || prevent_self_review || reviewers || deployment_branch_policy || variables || deployment_protection_rules;
-    }
+    return (
+      wait_timer ||
+      prevent_self_review ||
+      reviewers ||
+      deployment_branch_policy ||
+      variables ||
+      deployment_protection_rules
+    )
+  }
 
-    async update(existing, attrs) {
-        const {wait_timer, prevent_self_review, reviewers, deployment_branch_policy, variables, deployment_protection_rules} = this.getChanged(existing, attrs);
+  async update (existing, attrs) {
+    const {
+      wait_timer,
+      prevent_self_review,
+      reviewers,
+      deployment_branch_policy,
+      variables,
+      deployment_protection_rules
+    } = this.getChanged(existing, attrs)
 
-        if(wait_timer || prevent_self_review || reviewers || deployment_branch_policy) {
-            await this.github.request(`PUT /repos/:org/:repo/environments/:environment_name`, {
-                org: this.repo.owner,
-                repo: this.repo.repo,
-                environment_name: attrs.name,
-                wait_timer: attrs.wait_timer,
-                prevent_self_review: attrs.prevent_self_review,
-                reviewers: attrs.reviewers,
-                deployment_branch_policy: attrs.deployment_branch_policy === null ? null : {
-                    protected_branches: attrs.deployment_branch_policy.protected_branches,
-                    custom_branch_policies: !!attrs.deployment_branch_policy.custom_branch_policies
+    if (
+      wait_timer ||
+      prevent_self_review ||
+      reviewers ||
+      deployment_branch_policy
+    ) {
+      await this.github.request(
+        'PUT /repos/:org/:repo/environments/:environment_name',
+        {
+          org: this.repo.owner,
+          repo: this.repo.repo,
+          environment_name: attrs.name,
+          wait_timer: attrs.wait_timer,
+          prevent_self_review: attrs.prevent_self_review,
+          reviewers: attrs.reviewers,
+          deployment_branch_policy:
+            attrs.deployment_branch_policy === null
+              ? null
+              : {
+                  protected_branches:
+                    attrs.deployment_branch_policy.protected_branches,
+                  custom_branch_policies:
+                    !!attrs.deployment_branch_policy.custom_branch_policies
                 }
-            })
         }
-
-        if(deployment_branch_policy && attrs.deployment_branch_policy && attrs.deployment_branch_policy.custom_branch_policies) {
-            const existingPolicies = (await this.github.request('GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
-                org: this.repo.owner,
-                repo: this.repo.repo,
-                environment_name: attrs.name
-            })).data.branch_policies;
-
-            for(let policy of existingPolicies) {
-                await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:branch_policy_id', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    branch_policy_id: policy.id
-                });
-            }
-
-            for(let policy of attrs.deployment_branch_policy.custom_branch_policies) {
-                await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    name: policy
-                });
-            }
-        }
-
-        if(variables) {
-            let existingVariables = [...existing.variables];
-
-            for(let variable of attrs.variables) {
-                const existingVariable = existingVariables.find((_var) => _var.name === variable.name);
-                if(existingVariable) {
-                    existingVariables = existingVariables.filter(_var => _var.name !== variable.name);
-                    if(existingVariable.value !== variable.value) {
-                        await this.github.request(`PATCH /repos/:org/:repo/environments/:environment_name/variables/:variable_name`, {
-                            org: this.repo.owner,
-                            repo: this.repo.repo,
-                            environment_name: attrs.name,
-                            variable_name: variable.name,
-                            value: variable.value
-                        });
-                    }
-                }
-                else {
-                    await this.github.request(`POST /repos/:org/:repo/environments/:environment_name/variables`, {
-                        org: this.repo.owner,
-                        repo: this.repo.repo,
-                        environment_name: attrs.name,
-                        name: variable.name,
-                        value: variable.value
-                    });
-                }
-            }
-
-            for(let variable of existingVariables) {
-                await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name/variables/:variable_name', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    variable_name: variable.name
-                });
-            }
-        }
-
-        if(deployment_protection_rules) {
-            let existingRules = [...existing.deployment_protection_rules];
-
-            for(let rule of attrs.deployment_protection_rules) {
-                const existingRule = existingRules.find((_rule) => _rule.id === rule.id);
-
-                if(!existingRule) {
-                    await this.github.request(`POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules`, {
-                        org: this.repo.owner,
-                        repo: this.repo.repo,
-                        environment_name: attrs.name,
-                        integration_id: rule.app_id
-                    });
-                }
-            }
-
-            for(let rule of existingRules) {
-                await this.github.request('DELETE /repos/:org/:repo/environments/:environment_name/deployment_protection_rules/:rule_id', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    rule_id: rule.id
-                });
-            }
-        }
+      )
     }
 
-    async add(attrs) {
-        await this.github.request(`PUT /repos/:org/:repo/environments/:environment_name`, {
+    if (
+      deployment_branch_policy &&
+      attrs.deployment_branch_policy &&
+      attrs.deployment_branch_policy.custom_branch_policies
+    ) {
+      const existingPolicies = (
+        await this.github.request(
+          'GET /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org: this.repo.owner,
+            repo: this.repo.repo,
+            environment_name: attrs.name
+          }
+        )
+      ).data.branch_policies
+
+      for (const policy of existingPolicies) {
+        await this.github.request(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment-branch-policies/:branch_policy_id',
+          {
             org: this.repo.owner,
             repo: this.repo.repo,
             environment_name: attrs.name,
-            wait_timer: attrs.wait_timer,
-            prevent_self_review: attrs.prevent_self_review,
-            reviewers: attrs.reviewers,
-            deployment_branch_policy: attrs.deployment_branch_policy == null ? null : {
-                protected_branches: !!attrs.deployment_branch_policy.protected_branches,
-                custom_branch_policies: !!attrs.deployment_branch_policy.custom_branch_policies
-            }
-        });
-
-        if(attrs.deployment_branch_policy && attrs.deployment_branch_policy.custom_branch_policies) {
-
-            for(let policy of attrs.deployment_branch_policy.custom_branch_policies) {
-                await this.github.request('POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies', {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    name: policy.name
-                });
-            }
-
-        }
-
-        if(attrs.variables) {
-
-            for(let variable of attrs.variables) {
-                await this.github.request(`POST /repos/:org/:repo/environments/:environment_name/variables`, {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    name: variable.name,
-                    value: variable.value
-                });
-            }
-
+            branch_policy_id: policy.id
           }
+        )
+      }
 
-        if(attrs.deployment_protection_rules) {
-
-            for(let rule of attrs.deployment_protection_rules) {
-                await this.github.request(`POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules`, {
-                    org: this.repo.owner,
-                    repo: this.repo.repo,
-                    environment_name: attrs.name,
-                    integration_id: rule.app_id
-                });
-            }
-
-        }
-    }
-
-    async remove(existing) {
-        await this.github.request(`DELETE /repos/:org/:repo/environments/:environment_name`, {
+      for (const policy of attrs.deployment_branch_policy
+        .custom_branch_policies) {
+        await this.github.request(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
             org: this.repo.owner,
             repo: this.repo.repo,
-            environment_name: existing.name
-        });
+            environment_name: attrs.name,
+            name: policy
+          }
+        )
+      }
     }
 
-    sync () {
-      const resArray = []
-      if (this.entries) {
-        let filteredEntries = this.filterEntries()
-        return this.find().then(existingRecords => {
+    if (variables) {
+      let existingVariables = [...existing.variables]
 
+      for (const variable of attrs.variables) {
+        const existingVariable = existingVariables.find(
+          (_var) => _var.name === variable.name
+        )
+        if (existingVariable) {
+          existingVariables = existingVariables.filter(
+            (_var) => _var.name !== variable.name
+          )
+          if (existingVariable.value !== variable.value) {
+            await this.github.request(
+              'PATCH /repos/:org/:repo/environments/:environment_name/variables/:variable_name',
+              {
+                org: this.repo.owner,
+                repo: this.repo.repo,
+                environment_name: attrs.name,
+                variable_name: variable.name,
+                value: variable.value
+              }
+            )
+          }
+        } else {
+          await this.github.request(
+            'POST /repos/:org/:repo/environments/:environment_name/variables',
+            {
+              org: this.repo.owner,
+              repo: this.repo.repo,
+              environment_name: attrs.name,
+              name: variable.name,
+              value: variable.value
+            }
+          )
+        }
+      }
+
+      for (const variable of existingVariables) {
+        await this.github.request(
+          'DELETE /repos/:org/:repo/environments/:environment_name/variables/:variable_name',
+          {
+            org: this.repo.owner,
+            repo: this.repo.repo,
+            environment_name: attrs.name,
+            variable_name: variable.name
+          }
+        )
+      }
+    }
+
+    if (deployment_protection_rules) {
+      const existingRules = [...existing.deployment_protection_rules]
+
+      for (const rule of attrs.deployment_protection_rules) {
+        const existingRule = existingRules.find(
+          (_rule) => _rule.id === rule.id
+        )
+
+        if (!existingRule) {
+          await this.github.request(
+            'POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules',
+            {
+              org: this.repo.owner,
+              repo: this.repo.repo,
+              environment_name: attrs.name,
+              integration_id: rule.app_id
+            }
+          )
+        }
+      }
+
+      for (const rule of existingRules) {
+        await this.github.request(
+          'DELETE /repos/:org/:repo/environments/:environment_name/deployment_protection_rules/:rule_id',
+          {
+            org: this.repo.owner,
+            repo: this.repo.repo,
+            environment_name: attrs.name,
+            rule_id: rule.id
+          }
+        )
+      }
+    }
+  }
+
+  async add (attrs) {
+    await this.github.request(
+      'PUT /repos/:org/:repo/environments/:environment_name',
+      {
+        org: this.repo.owner,
+        repo: this.repo.repo,
+        environment_name: attrs.name,
+        wait_timer: attrs.wait_timer,
+        prevent_self_review: attrs.prevent_self_review,
+        reviewers: attrs.reviewers,
+        deployment_branch_policy:
+          attrs.deployment_branch_policy == null
+            ? null
+            : {
+                protected_branches:
+                  !!attrs.deployment_branch_policy.protected_branches,
+                custom_branch_policies:
+                  !!attrs.deployment_branch_policy.custom_branch_policies
+              }
+      }
+    )
+
+    if (
+      attrs.deployment_branch_policy &&
+      attrs.deployment_branch_policy.custom_branch_policies
+    ) {
+      for (const policy of attrs.deployment_branch_policy
+        .custom_branch_policies) {
+        await this.github.request(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment-branch-policies',
+          {
+            org: this.repo.owner,
+            repo: this.repo.repo,
+            environment_name: attrs.name,
+            name: policy.name
+          }
+        )
+      }
+    }
+
+    if (attrs.variables) {
+      for (const variable of attrs.variables) {
+        await this.github.request(
+          'POST /repos/:org/:repo/environments/:environment_name/variables',
+          {
+            org: this.repo.owner,
+            repo: this.repo.repo,
+            environment_name: attrs.name,
+            name: variable.name,
+            value: variable.value
+          }
+        )
+      }
+    }
+
+    if (attrs.deployment_protection_rules) {
+      for (const rule of attrs.deployment_protection_rules) {
+        await this.github.request(
+          'POST /repos/:org/:repo/environments/:environment_name/deployment_protection_rules',
+          {
+            org: this.repo.owner,
+            repo: this.repo.repo,
+            environment_name: attrs.name,
+            integration_id: rule.app_id
+          }
+        )
+      }
+    }
+  }
+
+  async remove (existing) {
+    await this.github.request(
+      'DELETE /repos/:org/:repo/environments/:environment_name',
+      {
+        org: this.repo.owner,
+        repo: this.repo.repo,
+        environment_name: existing.name
+      }
+    )
+  }
+
+  sync () {
+    const resArray = []
+    if (this.entries) {
+      const filteredEntries = this.filterEntries()
+      return this.find()
+        .then((existingRecords) => {
           // Remove any null or undefined values from the diffables (usually comes from repo override)
           for (const entry of filteredEntries) {
             for (const key of Object.keys(entry)) {
@@ -304,9 +476,9 @@ module.exports = class Environments extends Diffable {
 
           const changes = []
 
-          existingRecords.forEach(x => {
-            if (!filteredEntries.find(y => this.comparator(x, y))) {
-              const change = this.remove(x).then(res => {
+          existingRecords.forEach((x) => {
+            if (!filteredEntries.find((y) => this.comparator(x, y))) {
+              const change = this.remove(x).then((res) => {
                 if (this.nop) {
                   return resArray.push(res)
                 }
@@ -316,13 +488,13 @@ module.exports = class Environments extends Diffable {
             }
           })
 
-          filteredEntries.forEach(attrs => {
-            const existing = existingRecords.find(record => {
+          filteredEntries.forEach((attrs) => {
+            const existing = existingRecords.find((record) => {
               return this.comparator(record, attrs)
             })
 
             if (!existing) {
-              const change = this.add(attrs).then(res => {
+              const change = this.add(attrs).then((res) => {
                 if (this.nop) {
                   return resArray.push(res)
                 }
@@ -330,7 +502,7 @@ module.exports = class Environments extends Diffable {
               })
               changes.push(change)
             } else if (this.changed(existing, attrs)) {
-              const change = this.update(existing, attrs).then(res => {
+              const change = this.update(existing, attrs).then((res) => {
                 if (this.nop) {
                   return resArray.push(res)
                 }
@@ -344,20 +516,38 @@ module.exports = class Environments extends Diffable {
             return Promise.resolve(resArray)
           }
           return Promise.all(changes)
-        }).catch(e => {
+        })
+        .catch((e) => {
           if (this.nop) {
             if (e.status === 404) {
               // Ignore 404s which can happen in dry-run as the repo may not exist.
               return Promise.resolve(resArray)
             } else {
-              resArray.push(new NopCommand(this.constructor.name, this.repo, null, `error ${e} in ${this.constructor.name} for repo: ${JSON.stringify(this.repo)} entries ${JSON.stringify(this.entries)}`, 'ERROR'))
+              resArray.push(
+                new NopCommand(
+                  this.constructor.name,
+                  this.repo,
+                  null,
+                  `error ${e} in ${
+                    this.constructor.name
+                  } for repo: ${JSON.stringify(
+                    this.repo
+                  )} entries ${JSON.stringify(this.entries)}`,
+                  'ERROR'
+                )
+              )
               return Promise.resolve(resArray)
             }
           } else {
-            this.logError(`Error ${e} in ${this.constructor.name} for repo: ${JSON.stringify(this.repo)} entries ${JSON.stringify(this.entries)}`)
+            this.logError(
+              `Error ${e} in ${
+                this.constructor.name
+              } for repo: ${JSON.stringify(this.repo)} entries ${JSON.stringify(
+                this.entries
+              )}`
+            )
           }
         })
-      }
     }
-
+  }
 }

--- a/lib/plugins/environments.js
+++ b/lib/plugins/environments.js
@@ -301,7 +301,7 @@ module.exports = class Environments extends Diffable {
         )
         if (existingVariable) {
           existingVariables = existingVariables.filter(
-            (_var) => _var.name !== variable.name
+            (_var) => _var.name === variable.name
           )
           if (existingVariable.value !== variable.value) {
             await this.github.request(

--- a/test/unit/lib/plugins/environments.test.js
+++ b/test/unit/lib/plugins/environments.test.js
@@ -365,7 +365,7 @@ describe('Environments Plugin test suite', () => {
           name: environment_name,
           variables: [
             {
-              name: 'test',
+              name: 'TEST',
               value: 'test'
             }
           ]
@@ -392,11 +392,151 @@ describe('Environments Plugin test suite', () => {
         expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments', { org, repo });
         expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/variables', { org, repo, environment_name });
         expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', { org, repo, environment_name });
+        // https://docs.github.com/en/rest/actions/variables#create-an-environment-variable
+        // Body parameters name and value are case-sensitive!
         expect(github.request).toHaveBeenCalledWith('POST /repos/:org/:repo/environments/:environment_name/variables', expect.objectContaining({
           org,
           repo,
           environment_name: environment_name,
-          name: 'test',
+          name: 'TEST',
+          value: 'test'
+        }));
+      })
+    })
+  })
+
+  // patch variable
+  describe('When there are existing variables and one requires an update', () => {
+    it('detect divergence and add the variable', async () => {
+      //arrange
+      environment_name = 'variables_environment'
+      // represent config with a reviewers being a user and a team
+      const plugin = new Environments(undefined, github, { owner: org, repo }, [
+        {
+          name: environment_name,
+          variables: [
+            {
+              name: 'test',
+              value: 'test'
+            }
+          ]
+        }
+      ], log, errors);
+
+      //model an existing environment with no reviewers
+      when(github.request)
+        .calledWith('GET /repos/:org/:repo/environments', { org, repo })
+        .mockResolvedValue({
+          data: {
+            environments: [
+              fillEnvironment({
+                name: environment_name,
+                variables: []
+              })
+            ]
+          }
+        });
+
+      when(github.request)
+        .calledWith('GET /repos/:org/:repo/environments/:environment_name/variables', { org, repo, environment_name })
+        .mockResolvedValue({
+          data: {
+            variables: [
+              {
+                name: 'test',
+                value: 'old'
+              },
+              {
+                name: 'test2',
+                value: 'test2'
+              }
+            ]
+          }
+        })
+
+      //act - run sync() in environments.js
+      await plugin.sync().then(() => {
+        //assert - update the variables
+        expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments', { org, repo });
+        expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/variables', { org, repo, environment_name });
+        expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', { org, repo, environment_name });
+        // https://docs.github.com/en/rest/actions/variables#update-an-environment-variable
+        // URL parameter variable_name is case-insensitive!
+        expect(github.request).toHaveBeenCalledWith('PATCH /repos/:org/:repo/environments/:environment_name/variables/:variable_name', expect.objectContaining({
+          org,
+          repo,
+          environment_name: environment_name,
+          variable_name: expect.stringMatching(/test/i),
+          value: 'test'
+        }));
+      })
+    })
+  })
+
+  // patch variable
+  describe('When there are existing mixed-case variables and one requires an update', () => {
+    it('detect divergence and update the variable', async () => {
+      //arrange
+      environment_name = 'variables_environment'
+      // represent config with a reviewers being a user and a team
+      const plugin = new Environments(undefined, github, { owner: org, repo }, [
+        {
+          name: environment_name,
+          variables: [
+            {
+              name: 'TEST',
+              value: 'test'
+            }
+          ]
+        }
+      ], log, errors);
+
+      //model an existing environment with no reviewers
+      when(github.request)
+        .calledWith('GET /repos/:org/:repo/environments', { org, repo })
+        .mockResolvedValue({
+          data: {
+            environments: [
+              fillEnvironment({
+                name: environment_name,
+                variables: []
+              })
+            ]
+          }
+        });
+
+      when(github.request)
+        .calledWith('GET /repos/:org/:repo/environments/:environment_name/variables', { org, repo, environment_name })
+        .mockResolvedValue({
+          data: {
+            variables: [
+              {
+                name: 'TEST',
+                value: 'old'
+              },
+              {
+                name: 'TEST2',
+                value: 'test2'
+              }
+            ]
+          }
+        })
+
+      //act - run sync() in environments.js
+      await plugin.sync().then(() => {
+        //assert - update the variables
+        expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments', { org, repo });
+        // https://docs.github.com/en/rest/actions/variables#list-environment-variables
+        // Returned properties are case-sensitive!
+        expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/variables', { org, repo, environment_name });
+        expect(github.request).toHaveBeenCalledWith('GET /repos/:org/:repo/environments/:environment_name/deployment_protection_rules', { org, repo, environment_name });
+        // https://docs.github.com/en/rest/actions/variables#update-an-environment-variable
+        // URL parameter variable_name is case-insensitive!
+        expect(github.request).toHaveBeenCalledWith('PATCH /repos/:org/:repo/environments/:environment_name/variables/:variable_name', expect.objectContaining({
+          org,
+          repo,
+          environment_name: environment_name,
+          variable_name: expect.stringMatching(/test/i),
           value: 'test'
         }));
       })


### PR DESCRIPTION
Github REST API supports case-sensitive names on this endpoint
so we should always create (POST) variables with the desired case.

On subsequent GET, PATCH, and DELETE requests the Github REST API
will use loose matching to find any existing objects, ignoring case.

So in general we need to force to lowercase to perform diffs, and respect
the provided case for create, but for all other calls it doesn't matter
which case is used.